### PR TITLE
[run-tests] Add nonPersistentSubscriptionExpirationTimeMinutes configuration

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -224,6 +224,10 @@ activeConsumerFailoverDelayTimeMillis=1000
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0
 
+# How long to delete inactive subscriptions from last consuming for non-persistent topic.
+# When it is 0, inactive subscriptions are not deleted automatically
+nonPersistentSubscriptionExpirationTimeMinutes=0
+
 # Enable subscription message redelivery tracker to send redelivery count to consumer (default is enabled)
 subscriptionRedeliveryTrackerEnabled=true
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -707,6 +707,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int subscriptionExpirationTimeMinutes = 0;
     @FieldContext(
             category = CATEGORY_POLICIES,
+            doc = "How long to delete inactive subscriptions from last consuming for non-persistent topic."
+                    + " When it is 0, inactive subscriptions are not deleted automatically",
+            minValue = 0
+    )
+    private int nonPersistentSubscriptionExpirationTimeMinutes = 0;
+    @FieldContext(
+            category = CATEGORY_POLICIES,
             dynamic = true,
             doc = "Enable subscription message redelivery tracker to send redelivery "
                     + "count to consumer (default is enabled)"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1026,8 +1026,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     .getPolicies(name.getNamespaceObject())
                     .orElseThrow(MetadataStoreException.NotFoundException::new);
             final int defaultExpirationTime = brokerService.pulsar().getConfiguration()
-                    .getSubscriptionExpirationTimeMinutes();
-            final Integer nsExpirationTime = policies.subscription_expiration_time_minutes;
+                    .getNonPersistentSubscriptionExpirationTimeMinutes();
+            final Integer nsExpirationTime = policies.non_persistent_subscription_expiration_time_minutes;
             final long expirationTimeMillis = TimeUnit.MINUTES
                     .toMillis(nsExpirationTime == null ? defaultExpirationTime : nsExpirationTime);
             if (expirationTimeMillis > 0) {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -62,6 +62,8 @@ public class Policies {
     @SuppressWarnings("checkstyle:MemberName")
     public Integer subscription_expiration_time_minutes = null;
     @SuppressWarnings("checkstyle:MemberName")
+    public Integer non_persistent_subscription_expiration_time_minutes = null;
+    @SuppressWarnings("checkstyle:MemberName")
     public RetentionPolicies retention_policies = null;
     public boolean deleted = false;
     public static final String FIRST_BOUNDARY = "0x00000000";
@@ -141,7 +143,8 @@ public class Policies {
                 clusterSubscribeRate, deduplicationEnabled, autoTopicCreationOverride,
                 autoSubscriptionCreationOverride, persistence,
                 bundles, latency_stats_sample_rate,
-                message_ttl_in_seconds, subscription_expiration_time_minutes, retention_policies,
+                message_ttl_in_seconds, subscription_expiration_time_minutes,
+                non_persistent_subscription_expiration_time_minutes, retention_policies,
                 encryption_required, delayed_delivery_policies, inactive_topic_policies,
                 subscription_auth_mode,
                 max_producers_per_topic,
@@ -180,6 +183,8 @@ public class Policies {
                     && Objects.equals(message_ttl_in_seconds,
                             other.message_ttl_in_seconds)
                     && Objects.equals(subscription_expiration_time_minutes, other.subscription_expiration_time_minutes)
+                    && Objects.equals(non_persistent_subscription_expiration_time_minutes,
+                            other.non_persistent_subscription_expiration_time_minutes)
                     && Objects.equals(retention_policies, other.retention_policies)
                     && Objects.equals(encryption_required, other.encryption_required)
                     && Objects.equals(delayed_delivery_policies, other.delayed_delivery_policies)


### PR DESCRIPTION
This PR is for running tests for upstream PR https://github.com/apache/pulsar/pull/19369.

<!-- Before creating this PR, please ensure that the fork https://github.com/tjiuming/pulsar is up to date with https://github.com/apache/pulsar -->